### PR TITLE
Update Documenter.jl compat to 1.0

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -5,5 +5,5 @@ OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 
 [compat]
 DiffEqDevTools = "2"
-Documenter = "0.27"
+Documenter = "1"
 OrdinaryDiffEq = "6"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,12 +14,7 @@ makedocs(sitename = "SciML Developer Documentation",
     authors = "Chris Rackauckas",
     modules = [DiffEqDevTools, OrdinaryDiffEq],
     clean = true, doctest = false,
-    strict = [
-        :doctest,
-        :linkcheck,
-        :parse_error,
-        :example_block        # Other available options are        # :autodocs_block, :cross_references, :docs_block, :eval_block, :example_block, :footnote, :meta_block, :missing_docs, :setup_block
-    ],
+    warnonly = Documenter.except(:doctest, :linkcheck, :parse_error, :example_block),
     format = Documenter.HTML(analytics = "UA-90474609-3",
         assets = ["assets/favicon.ico"],
         canonical = "https://docs.sciml.ai/DiffEqDevDocs/stable/"),


### PR DESCRIPTION
## Summary

- Update docs/Project.toml to use Documenter = "1" instead of "0.27"
- Update docs/make.jl to use `warnonly` instead of the deprecated `strict` keyword
  - In Documenter 1.0, `strict` was replaced with `warnonly` with inverted logic
  - Using `Documenter.except()` to maintain the same behavior (fail on doctest, linkcheck, parse_error, example_block errors)

Closes #66

## Test plan

- [x] Tested documentation build locally with Documenter v1.16.1
- [x] Build completes successfully
- [ ] CI passes

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)