### PR TITLE
Switch from JuliaFormatter to Runic.jl for code formatting

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,3 +1,0 @@
-style = "sciml"
-format_markdown = true
-format_docstrings = true

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,0 +1,19 @@
+name: format-check
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'main'
+      - 'release-'
+    tags: '*'
+  pull_request:
+
+jobs:
+  runic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: fredrikekre/runic-action@v1
+        with:
+          version: '1'

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,23 +3,29 @@ using OrdinaryDiffEq
 using Documenter
 
 DocMeta.setdocmeta!(
-    DiffEqDevTools, :DocTestSetup, :(using DiffEqDevTools); recursive = true)
+    DiffEqDevTools, :DocTestSetup, :(using DiffEqDevTools); recursive = true
+)
 
 cp("./docs/Manifest.toml", "./docs/src/assets/Manifest.toml", force = true)
 cp("./docs/Project.toml", "./docs/src/assets/Project.toml", force = true)
 
 include("pages.jl")
 
-makedocs(sitename = "SciML Developer Documentation",
+makedocs(
+    sitename = "SciML Developer Documentation",
     authors = "Chris Rackauckas",
     modules = [DiffEqDevTools, OrdinaryDiffEq],
     clean = true, doctest = false,
     warnonly = Documenter.except(:doctest, :linkcheck, :parse_error, :example_block),
-    format = Documenter.HTML(analytics = "UA-90474609-3",
+    format = Documenter.HTML(
+        analytics = "UA-90474609-3",
         assets = ["assets/favicon.ico"],
-        canonical = "https://docs.sciml.ai/DiffEqDevDocs/stable/"),
-    pages = pages)
+        canonical = "https://docs.sciml.ai/DiffEqDevDocs/stable/"
+    ),
+    pages = pages
+)
 
 deploydocs(;
     repo = "github.com/SciML/DiffEqDevDocs.jl",
-    devbranch = "master")
+    devbranch = "master"
+)

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -1,20 +1,20 @@
 pages = Any[
-"Home" => "index.md",
-"Contributor Guide" => Any[
-    "contributing/ecosystem_overview.md",
-    "contributing/adding_packages.md",
-    "contributing/adding_algorithms.md",
-    "contributing/defining_problems.md",
-    "contributing/diffeq_internals.md",
-    "contributing/type_traits.md"
-],
-"Algorithm Development Tools" => Any[
-    "alg_dev/test_problems.md",
-    "alg_dev/convergence.md",
-    "alg_dev/benchmarks.md"
-],
-"Internal Documentation" => Any[
-    "internals/notes_on_algorithms.md",
-    "internals/tableaus.md"
-]
+    "Home" => "index.md",
+    "Contributor Guide" => Any[
+        "contributing/ecosystem_overview.md",
+        "contributing/adding_packages.md",
+        "contributing/adding_algorithms.md",
+        "contributing/defining_problems.md",
+        "contributing/diffeq_internals.md",
+        "contributing/type_traits.md",
+    ],
+    "Algorithm Development Tools" => Any[
+        "alg_dev/test_problems.md",
+        "alg_dev/convergence.md",
+        "alg_dev/benchmarks.md",
+    ],
+    "Internal Documentation" => Any[
+        "internals/notes_on_algorithms.md",
+        "internals/tableaus.md",
+    ],
 ]


### PR DESCRIPTION
## Summary
- Updated CI workflow to use `fredrikekre/runic-action@v1` instead of JuliaFormatter
- Removed `.JuliaFormatter.toml` configuration file
- Reformatted all source files with Runic.jl

## Changes
This PR migrates the code formatting from JuliaFormatter with SciMLStyle to Runic.jl. Runic.jl is an opinionated formatter (similar to Go's gofmt) that requires no configuration.

Key differences from JuliaFormatter:
- Explicit `return` statements are added where implicit
- Different indentation and alignment for continuation lines
- Consistent multiline formatting for function arguments

## Test plan
- [ ] CI format check passes with Runic.jl
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)